### PR TITLE
correctly handle query lambda version when the sql changes

### DIFF
--- a/rockset/provider_test.go
+++ b/rockset/provider_test.go
@@ -1,6 +1,7 @@
 package rockset
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io/ioutil"
@@ -8,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"text/template"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -88,6 +90,24 @@ func getHCL(filename string) string {
 	}
 
 	return hcl
+}
+
+// getHCLTemplate returns a rendered HCL config
+func getHCLTemplate(filename string, data any) string {
+	hclPath := filepath.Join("..", "testdata", filename)
+	hcl, err := getFileContents(hclPath)
+	if err != nil {
+		log.Fatalf("Unexpected error loading test data %s", hclPath)
+	}
+
+	var buf []byte
+	rendered := bytes.NewBuffer(buf)
+	t := template.Must(template.New("hcl").Parse(hcl))
+	if err = t.Execute(rendered, data); err != nil {
+		log.Fatalf("failed to render %s: %v", filename, err)
+	}
+
+	return rendered.String()
 }
 
 /*

--- a/rockset/resource_query_lambda.go
+++ b/rockset/resource_query_lambda.go
@@ -21,6 +21,8 @@ func resourceQueryLambda() *schema.Resource { //nolint:funlen
 		UpdateContext: resourceQueryLambdaUpdate,
 		DeleteContext: resourceQueryLambdaDelete,
 
+		CustomizeDiff: resourceQueryLambdaDiff,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -89,6 +91,15 @@ func resourceQueryLambda() *schema.Resource { //nolint:funlen
 			},
 		},
 	}
+}
+
+// resourceQueryLambdaDiff checks if anything in the sql has changed, and if so, it'll
+// signal that the computer version will change
+func resourceQueryLambdaDiff(ctx context.Context, diff *schema.ResourceDiff, i interface{}) error {
+	if diff.HasChange("sql") {
+		return diff.SetNewComputed("version")
+	}
+	return nil
 }
 
 type qlFn func(context.Context, string, string, string, ...option.CreateQueryLambdaOption) (openapi.QueryLambdaVersion,

--- a/testdata/query_lambda_no_defaults.tf
+++ b/testdata/query_lambda_no_defaults.tf
@@ -1,8 +1,15 @@
 resource rockset_query_lambda test {
   workspace = "commons"
-  name      = "terraform-provider-acceptance-tests-query-lambda-no-defaults"
+  name      = "tpat-ql-diff"
   description = "basic lambda"
   sql {
-    query = "SELECT * FROM commons._events LIMIT 1"
+    query = "{{ .Query }}"
   }
+}
+
+resource rockset_query_lambda_tag test {
+  name = "test"
+  workspace = rockset_query_lambda.test.workspace
+  query_lambda = rockset_query_lambda.test.name
+  version = rockset_query_lambda.test.version
 }


### PR DESCRIPTION
when the sql changes, the query lambda version will change, and the `terraform plan` needs to take that into account
