### PR TITLE
use update on query_lambda_tag changes

### DIFF
--- a/rockset/resource_query_lambda_tag.go
+++ b/rockset/resource_query_lambda_tag.go
@@ -19,6 +19,7 @@ func resourceQueryLambdaTag() *schema.Resource {
 		CreateContext: resourceQueryLambdaTagCreate,
 		ReadContext:   resourceQueryLambdaTagRead,
 		DeleteContext: resourceQueryLambdaTagDelete,
+		UpdateContext: resourceQueryLambdaTagCreate,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -49,7 +50,6 @@ func resourceQueryLambdaTag() *schema.Resource {
 				Description:  "Version of the query lambda this tag should point to.",
 				Type:         schema.TypeString,
 				Required:     true,
-				ForceNew:     true,
 				ValidateFunc: rocksetNameValidator,
 			},
 		},


### PR DESCRIPTION
we didn't have support for updating query_lambda_tags before, but now that we do, we should take advantage of it
