### PR TITLE
Do not store obfuscated value of the API key

### DIFF
--- a/rockset/resource_api_key.go
+++ b/rockset/resource_api_key.go
@@ -142,10 +142,7 @@ func resourceApiKeyRead(ctx context.Context, d *schema.ResourceData, meta interf
 		return diag.FromErr(err)
 	}
 
-	err = d.Set("key", foundApiKey.GetKey())
-	if err != nil {
-		return diag.FromErr(err)
-	}
+	// We intentionally omit here the actual key, as it comes obfuscated from the API.
 
 	// The user field is exposed in no way by the api
 	// We can only use the field set from the id


### PR DESCRIPTION
We found a problem while using this provider to create an API key and then store the actual key value in another system.

The problem can be reproduced like this:
- apply the config creating the API key
- change the config to save the output key in a file and apply the change
- then the file will contain the obfuscated key.


In this PR I am just making sure that the `resourceApiKeyRead` does not update the key in the state.