### PR TITLE
remove EOLed fields

### DIFF
--- a/rockset/resource_collection.go
+++ b/rockset/resource_collection.go
@@ -22,10 +22,12 @@ import (
 func baseCollectionSchema() map[string]*schema.Schema { //nolint:funlen
 	return map[string]*schema.Schema{
 		"clustering_key": {
-			Description: "List of clustering fields.",
-			Type:        schema.TypeList,
-			ForceNew:    true,
-			Optional:    true,
+			Description:   "List of clustering fields.",
+			Type:          schema.TypeList,
+			ForceNew:      true,
+			Optional:      true,
+			Deprecated:    "Use a `field_mapping_query` instead",
+			ConflictsWith: []string{"field_mapping_query"},
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"field_name": {
@@ -61,11 +63,12 @@ func baseCollectionSchema() map[string]*schema.Schema { //nolint:funlen
 			Optional:    true,
 		},
 		"field_mapping": {
-			Description: "List of field mappings.",
-			Type:        schema.TypeList,
-			ForceNew:    true,
-			Optional:    true,
-			Deprecated:  "Use a `field_mapping_query` instead",
+			Description:   "List of field mappings.",
+			Type:          schema.TypeList,
+			ForceNew:      true,
+			Optional:      true,
+			Deprecated:    "Use a `field_mapping_query` instead",
+			ConflictsWith: []string{"field_mapping_query"},
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"name": {
@@ -167,59 +170,7 @@ For more information see https://rockset.com/docs/ingest-transformation/`,
 			ForceNew: true,
 			Optional: true,
 			// TODO deprecate in favor of ingest_transformation
-			// TODO validate that insert_only is set to true
-		},
-		"field_schemas": {
-			Description: "List of field schemas.",
-			Type:        schema.TypeList,
-			ForceNew:    true,
-			Optional:    true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"field_name": {
-						Description: "The name of a field. Parsed as a SQL qualified name.",
-						Type:        schema.TypeString,
-						ForceNew:    true,
-						Required:    true,
-					},
-					"index_mode": {
-						Description: "Whether to have index or no_index.",
-						Type:        schema.TypeString,
-						ForceNew:    true,
-						Required:    true,
-						ValidateFunc: validation.StringInSlice(
-							[]string{"index", "no_index"},
-							false), // Ignore case false, must do exact match
-					},
-					"range_index_mode": {
-						Description: "Whether to have v1_index or no_index.",
-						Type:        schema.TypeString,
-						ForceNew:    true,
-						Required:    true,
-						ValidateFunc: validation.StringInSlice(
-							[]string{"v1_index", "no_index"},
-							false), // Ignore case false, must do exact match
-					},
-					"type_index_mode": {
-						Description: "Whether to have index or no_index.",
-						Type:        schema.TypeString,
-						ForceNew:    true,
-						Required:    true,
-						ValidateFunc: validation.StringInSlice(
-							[]string{"index", "no_index"},
-							false), // Ignore case false, must do exact match
-					},
-					"column_index_mode": {
-						Description: "Whether to have store or no_store.",
-						Type:        schema.TypeString,
-						ForceNew:    true,
-						Required:    true,
-						ValidateFunc: validation.StringInSlice(
-							[]string{"store", "no_store"},
-							false), // Ignore case false, must do exact match
-					},
-				},
-			},
+			// TODO validate that insert_only is set to true and that neither field_mapping nor clustering_key is set
 		},
 		"insert_only": {
 			Type:        schema.TypeBool,
@@ -228,42 +179,6 @@ For more information see https://rockset.com/docs/ingest-transformation/`,
 			Default:     false,
 			Description: "If true disallows updates and deletes, but makes indexing more efficient",
 		},
-		"inverted_index_group_encoding_options": {
-			Description: "Inverted index group encoding options.",
-			Type:        schema.TypeSet,
-			ForceNew:    true,
-			Optional:    true,
-			MinItems:    0,
-			MaxItems:    1,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"group_size": {
-						Description: "Group size.",
-						Type:        schema.TypeInt,
-						ForceNew:    true,
-						Required:    true,
-					},
-					"restart_length": {
-						Description: "Restart length.",
-						Type:        schema.TypeInt,
-						ForceNew:    true,
-						Required:    true,
-					},
-					"event_time_codec": {
-						Description: "Event time codec.",
-						Type:        schema.TypeString,
-						ForceNew:    true,
-						Required:    true,
-					},
-					"doc_id_codec": {
-						Description: "Doc id codec.",
-						Type:        schema.TypeString,
-						ForceNew:    true,
-						Required:    true,
-					},
-				},
-			},
-		}, // End inverted_index_group_encoding_options
 		"name": {
 			Description:  "Unique identifier for the collection. Can contain alphanumeric or dash characters.",
 			Type:         schema.TypeString,

--- a/rockset/resource_dynamodb_collection.go
+++ b/rockset/resource_dynamodb_collection.go
@@ -46,12 +46,6 @@ func dynamoDBCollectionSchema() map[string]*schema.Schema {
 						ForceNew:    true,
 						Optional:    true,
 					},
-					"field_mapping_query": {
-						Type:        schema.TypeString,
-						ForceNew:    true,
-						Optional:    true,
-						Description: "Field mapping SQL query.",
-					},
 					"scan_start_time": {
 						Description: "DynamoDB scan start time.",
 						Type:        schema.TypeString,

--- a/rockset/resource_gcs_collection.go
+++ b/rockset/resource_gcs_collection.go
@@ -60,12 +60,6 @@ func gcsCollectionSchema() map[string]*schema.Schema {
 					"format": formatSchema(),
 					"csv":    csvSchema(),
 					"xml":    xmlSchema(),
-					"field_mapping_query": {
-						Type:        schema.TypeString,
-						ForceNew:    true,
-						Optional:    true,
-						Description: "Field mapping SQL query.",
-					},
 				},
 			},
 		},

--- a/rockset/resource_mongodb_collection.go
+++ b/rockset/resource_mongodb_collection.go
@@ -40,12 +40,6 @@ func mongoDBCollectionSchema() map[string]*schema.Schema {
 						ForceNew:    true,
 						Required:    true,
 					},
-					"field_mapping_query": {
-						Type:        schema.TypeString,
-						ForceNew:    true,
-						Optional:    true,
-						Description: "Field mapping SQL query.",
-					},
 					"scan_start_time": {
 						Description: "MongoDB scan start time.",
 						Type:        schema.TypeString,

--- a/rockset/resource_s3_collection.go
+++ b/rockset/resource_s3_collection.go
@@ -50,12 +50,6 @@ func s3CollectionSchema() map[string]*schema.Schema {
 					"format": formatSchema(),
 					"csv":    csvSchema(),
 					"xml":    xmlSchema(),
-					"field_mapping_query": {
-						Type:        schema.TypeString,
-						ForceNew:    true,
-						Optional:    true,
-						Description: "Field mapping SQL query.",
-					},
 				},
 			},
 		},

--- a/rockset/resource_user.go
+++ b/rockset/resource_user.go
@@ -2,12 +2,9 @@ package rockset
 
 import (
 	"context"
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/rockset/rockset-go-client"
-	"github.com/rockset/rockset-go-client/openapi"
 )
 
 func resourceUser() *schema.Resource {
@@ -66,7 +63,7 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interfac
 
 	email := d.Id()
 
-	user, err := getUserByEmail(ctx, rc, email)
+	user, err := rc.GetUser(ctx, email)
 	if err != nil {
 		return checkForNotFoundError(d, err)
 	}
@@ -95,26 +92,4 @@ func resourceUserDelete(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	return diags
-}
-
-func getUserByEmail(ctx context.Context, rc *rockset.RockClient, email string) (*openapi.User, error) {
-	// The api currently has no get user method
-	users, err := rc.ListUsers(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	var foundUser openapi.User
-	for _, currentUser := range users {
-		if currentUser.Email == email {
-			foundUser = currentUser
-			break
-		}
-	}
-
-	if foundUser.GetEmail() == "" { // Failed to find
-		return nil, fmt.Errorf("user not found in user list")
-	}
-
-	return &foundUser, nil
 }

--- a/rockset/resource_user_test.go
+++ b/rockset/resource_user_test.go
@@ -72,7 +72,7 @@ func testAccCheckRocksetUserDestroy(s *terraform.State) error {
 		}
 
 		email := rs.Primary.ID
-		_, err := getUserByEmail(testCtx, rc, email)
+		_, err := rc.GetUser(testCtx, email)
 
 		// An error would mean we didn't find the key, we expect an error
 		if err == nil {
@@ -94,12 +94,12 @@ func testAccCheckRocksetUserExists(resource string, user *openapi.User) resource
 		}
 
 		email := rs.Primary.ID
-		resp, err := getUserByEmail(testCtx, rc, email)
+		resp, err := rc.GetUser(testCtx, email)
 		if err != nil {
 			return err
 		}
 
-		*user = *resp
+		*user = resp
 
 		return nil
 	}
@@ -108,7 +108,7 @@ func testAccCheckRocksetUserExists(resource string, user *openapi.User) resource
 func testAccUserRoleListMatches(user *openapi.User, expectedRoles []string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 		if !reflect.DeepEqual(user.GetRoles(), expectedRoles) {
-			return fmt.Errorf("expected %s collections, got %s", expectedRoles, user.GetRoles())
+			return fmt.Errorf("expected %s roles, got %s", expectedRoles, user.GetRoles())
 		}
 
 		return nil


### PR DESCRIPTION
Removes `getUserByEmail` which is a method available on the `RockClient` and `field_mapping_query` which is injected from the base collection.

Removes `getUserByEmail()` as it is available in the REST API.