### PR TITLE
resource cleanup

### DIFF
--- a/rockset/provider.go
+++ b/rockset/provider.go
@@ -159,7 +159,7 @@ func mergeSchemas(mergeOnto map[string]*schema.Schema, toMerge map[string]*schem
 	return mergeOnto
 }
 
-// checkForNotFoundError check is the error is a Rockset NotFoundError, and then clears the id which makes
+// checkForNotFoundError checks if err is a Rockset NotFoundError, and then clears the id which makes
 // terraform create the resource, but if it isn't a NotFoundError it will return the error wrapped in diag.Diagnostics
 func checkForNotFoundError(d *schema.ResourceData, err error) diag.Diagnostics {
 	var re rockset.Error

--- a/rockset/resource_dynamodb_collection.go
+++ b/rockset/resource_dynamodb_collection.go
@@ -136,7 +136,7 @@ func resourceDynamoDBCollectionRead(ctx context.Context, d *schema.ResourceData,
 
 	collection, err := rc.GetCollection(ctx, workspace, name)
 	if err != nil {
-		return diag.FromErr(err)
+		return checkForNotFoundError(d, err)
 	}
 
 	// Gets all the fields any generic collection has

--- a/rockset/resource_workspace.go
+++ b/rockset/resource_workspace.go
@@ -75,7 +75,7 @@ func resourceWorkspaceRead(ctx context.Context, d *schema.ResourceData, meta int
 
 	workspace, err := rc.GetWorkspace(ctx, name)
 	if err != nil {
-		return diag.FromErr(err)
+		return checkForNotFoundError(d, err)
 	}
 
 	err = d.Set("name", workspace.GetName())


### PR DESCRIPTION
removes use of deprecated `prefix`
