### PR TITLE
add a guardrail for connecting to the correct org

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -55,12 +55,15 @@ resource rockset_s3_collection cities {
 
 * `api_key` - (optional) Your Rockset [API key](https://rockset.com/docs/rest-api/#createapikey). If not present it will be sourced from the `ROCKSET_APIKEY` environment variable.
 * `api_server` - (optional) Your Rockset API server. If not present it will be sourced from the `ROCKSET_APISERVER` environment variable.
+* `organization_id` - (optional) The ID of the organization to connect to. If this is set, the provider will validate that the `organization_id` matches the `organization_id` of the api key. If it does not match, the provider will return an error.
 
 The preferred configuration method is by environment variables, as it doesn't expose the API key in a configuration file.
 
 For a list of valid options for Rockset API server visit:
 
 https://rockset.com/docs/rest-api/
+
+-> If you use different organizations for development and production, the `organization_id` is useful for ensuring that the provider is connecting to the expected organization, as the API key doesn't have any visible identifier.
 
 ## Known issues
 

--- a/rockset/provider.go
+++ b/rockset/provider.go
@@ -19,6 +19,7 @@ import (
 type Config struct {
 	APIKey    string
 	APIServer string
+	OrgID     string
 }
 
 func Provider() *schema.Provider {
@@ -71,6 +72,14 @@ func Provider() *schema.Provider {
 				Default:     "",
 				Description: "The API server for accessing Rockset",
 			},
+			"organization_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+				Description: "The ID of the organization to connect to. " +
+					"If this is set, the provider will validate that the organization_id matches the organization_id " +
+					"of the api key. If it does not match, the provider will return an error.\n",
+			},
 		},
 		ConfigureContextFunc: providerConfigure,
 	}
@@ -80,6 +89,7 @@ func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, 
 	config := Config{
 		APIKey:    d.Get("api_key").(string),
 		APIServer: d.Get("api_server").(string),
+		OrgID:     d.Get("organization_id").(string),
 	}
 
 	return config.Client()
@@ -105,11 +115,23 @@ func (c *Config) Client() (interface{}, diag.Diagnostics) {
 		opts = append(opts, rockset.WithHTTPDebug())
 	}
 
-	// TODO pass rockset.WithUserAgent()
-
 	rc, err := rockset.NewClient(opts...)
 	if err != nil {
 		return nil, DiagFromErr(err)
+	}
+
+	// if we have an org id in the config, validate that it matches the org id of the api key
+	if c.OrgID != "" {
+		org, err := rc.GetOrganization(context.Background())
+		if err != nil {
+			return nil, DiagFromErr(err)
+		}
+
+		if org.GetId() != c.OrgID {
+			return nil, diag.Errorf(
+				"the organization configured in the provider `%s` does not match the organization of the api key: `%s`",
+				c.OrgID, org.GetId())
+		}
 	}
 
 	return rc, diags

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -29,12 +29,15 @@ Creating an S3 integration and a collection from Rockset's sample datasets.
 
 * `api_key` - (optional) Your Rockset [API key](https://rockset.com/docs/rest-api/#createapikey). If not present it will be sourced from the `ROCKSET_APIKEY` environment variable.
 * `api_server` - (optional) Your Rockset API server. If not present it will be sourced from the `ROCKSET_APISERVER` environment variable.
+* `organization_id` - (optional) The ID of the organization to connect to. If this is set, the provider will validate that the `organization_id` matches the `organization_id` of the api key. If it does not match, the provider will return an error.
 
 The preferred configuration method is by environment variables, as it doesn't expose the API key in a configuration file.
 
 For a list of valid options for Rockset API server visit:
 
 https://rockset.com/docs/rest-api/
+
+-> If you use different organizations for development and production, the `organization_id` is useful for ensuring that the provider is connecting to the expected organization, as the API key doesn't have any visible identifier.
 
 ## Known issues
 


### PR DESCRIPTION
for those who juggle multiple orgs, this can validate that you connect using the right one by setting `organization_id` in the provider, e.g.

```
provider "rockset" {
  organization_id = "foobar"
}
```

and then during `terraform plan` you get a failure if it doesn't match with the API key used:
```
│ Error: the organization configured in the provider `foobar` does not match the organization of the api key: `rockset`
│
│   with provider["registry.terraform.io/rockset/rockset"],
│   on main.tf line 10, in provider "rockset":
│   10: provider "rockset" {
```