### PR TITLE
Optionally update the alias when alias already exists

### DIFF
--- a/rockset/resource_alias.go
+++ b/rockset/resource_alias.go
@@ -3,6 +3,7 @@ package rockset
 import (
 	"context"
 	"reflect"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -98,12 +99,12 @@ func resourceAliasCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	_, err := rc.CreateAlias(ctx, workspace, name, collections, option.WithAliasDescription(d.Get("description").(string)))
 	if err != nil {
-        if !strings.Contains(err.Error(), "already exists in workspace") {
-		    return DiagFromErr(err)
+		if !strings.Contains(err.Error(), "already exists in workspace") {
+			return DiagFromErr(err)
 		}
 		err = rc.UpdateAlias(ctx, workspace, name, collections, option.WithAliasDescription(d.Get("description").(string)))
 		if err != nil {
-		    return DiagFromErr(err)
+			return DiagFromErr(err)
 		}
 	}
 

--- a/rockset/resource_alias.go
+++ b/rockset/resource_alias.go
@@ -98,7 +98,13 @@ func resourceAliasCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	_, err := rc.CreateAlias(ctx, workspace, name, collections, option.WithAliasDescription(d.Get("description").(string)))
 	if err != nil {
-		return DiagFromErr(err)
+        if !strings.Contains(err.Error(), "already exists in workspace") {
+		    return DiagFromErr(err)
+		}
+		err = rc.UpdateAlias(ctx, workspace, name, collections, option.WithAliasDescription(d.Get("description").(string)))
+		if err != nil {
+		    return DiagFromErr(err)
+		}
 	}
 
 	// There's a lag between create and update and the alias

--- a/rockset/resource_alias.go
+++ b/rockset/resource_alias.go
@@ -40,6 +40,13 @@ func resourceAlias() *schema.Resource {
 				Required:     true,
 				ValidateFunc: rocksetNameValidator,
 			},
+			"overwrite": {
+				Description: "Whether existing alias should be overwritten.",
+				Type:        schema.TypeString,
+				Default:     "false",
+				ForceNew:    false,
+				Optional:    true,
+			},
 			"description": {
 				Description: "Text describing the alias.",
 				Type:        schema.TypeString,
@@ -100,6 +107,10 @@ func resourceAliasCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	_, err := rc.CreateAlias(ctx, workspace, name, collections, option.WithAliasDescription(d.Get("description").(string)))
 	if err != nil {
 		if !strings.Contains(err.Error(), "already exists in workspace") {
+			return DiagFromErr(err)
+		}
+		overwrite := d.Get("overwrite").(string)
+		if overwrite != "true" {
 			return DiagFromErr(err)
 		}
 		err = rc.UpdateAlias(ctx, workspace, name, collections, option.WithAliasDescription(d.Get("description").(string)))


### PR DESCRIPTION
Alias creation fails when the alias with same name exists:

│ Error: Alias with name "c" already exists in workspace "qa".

This PR checks the error message and calls `UpdateAlias` in this case.
An option is added for backward compatibility:
```
   overwrite   = true
```
This is for https://github.com/rockset/terraform-provider-rockset/issues/100