### PR TITLE
handle write api adding a new source to existing collection

### DIFF
--- a/rockset/resource_gcs_collection.go
+++ b/rockset/resource_gcs_collection.go
@@ -120,7 +120,7 @@ func resourceGCSCollectionRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	// Gets all the fields relevant to an s3 collection
-	err = parseBucketCollection("gcs", &collection, d)
+	err = parseBucketCollection(ctx, "gcs", &collection, d)
 	if err != nil {
 		return DiagFromErr(err)
 	}

--- a/rockset/resource_s3_collection.go
+++ b/rockset/resource_s3_collection.go
@@ -137,7 +137,7 @@ func resourceS3CollectionRead(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	// Gets all the fields relevant to a s3 collection
-	err = parseBucketCollection("s3", &collection, d)
+	err = parseBucketCollection(ctx, "s3", &collection, d)
 	if err != nil {
 		return DiagFromErr(err)
 	}


### PR DESCRIPTION
If we have a S3 or GCS collection, and you write a new document to it using the write API,
it'll add a new source to the collection for the write api, which we didn't handle.

This addresses that case, and hides the collection from `terraform` until we refactor
the code to use the plugin framework and add support for sources.
